### PR TITLE
[Chapter-7~8] RISC-V 예외 처리 핸들러 및 매크로

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,3 @@
-{
-  "clangd.arguments": [
-    "--enable-config",
-    "--compile-commands-dir=.",
-    "--query-driver=/opt/homebrew/bin/riscv64-unknown-elf-gcc" 
-  ],
-  "clangd.onConfigChanged": "restart"
+{  
+  "C_Cpp.errorSquiggles": "enabled"
 }

--- a/kernel.h
+++ b/kernel.h
@@ -1,6 +1,96 @@
 #pragma once
+#include "common.h"
+
+/**
+ * @brief 예외 처리 시 저장된 레지스터들의 구조체 정의
+ * ra, 리턴 주소
+ * gp, 전역 포인터
+ * tp, 스레드 포인터
+ * t0 ~ t6, 임시 레지스터
+ * a0 ~ a7, 인자 레지스터
+ * s0 ~ s11, 저장 레지스터
+ * sp, 스택 포인터 */
+struct trap_frame {
+  uint32_t ra;
+  uint32_t gp;
+  uint32_t tp;
+  uint32_t t0;
+  uint32_t t1;
+  uint32_t t2;
+  uint32_t t3;
+  uint32_t t4;
+  uint32_t t5;
+  uint32_t t6;
+  uint32_t a0;
+  uint32_t a1;
+  uint32_t a2;
+  uint32_t a3;
+  uint32_t a4;
+  uint32_t a5;
+  uint32_t a6;
+  uint32_t a7;
+  uint32_t s0;
+  uint32_t s1;
+  uint32_t s2;
+  uint32_t s3;
+  uint32_t s4;
+  uint32_t s5;
+  uint32_t s6;
+  uint32_t s7;
+  uint32_t s8;
+  uint32_t s9;
+  uint32_t s10;
+  uint32_t s11;
+  uint32_t sp;
+
+  // 컴파일러에게 메모리 정렬(padding)을 하지 말라고 지시
+  // 구조체의 각 멤버가 연속된 메모리에 빈틈없이 배치
+  // 기본적으로 컴파일러는 성능을 위해 자동으로 정렬하지만
+  // 이 구조체는 정확한 메모리 레이아웃이 필요
+} __attribute__((packed));
+
+/**
+ * @brief CSR 레지스터를 읽는 매크로
+ * CSR (Control and Status Register), RISC-V에서 프로세서의 상태를 제어하고
+ * 모니터링하는 특수 목적 레지스터
+ */
+#define READ_CSR(reg)                                                          \
+  ({                                                                           \
+    unsigned long __tmp;                                                       \
+    __asm__ __volatile__("csrr %0, " #reg : "=r"(__tmp));                      \
+    __tmp;                                                                     \
+  })
+
+/**
+ * @brief CSR 레지스터에 값을 쓰는 매크로
+ *
+ */
+#define WRITE_CSR(reg, value)                                                  \
+  do {                                                                         \
+    uint32_t __tmp = (value);                                                  \
+    __asm__ __volatile__("csrw " #reg ", %0" ::"r"(__tmp));                    \
+  } while (0)
 
 struct sbiret {
   long error;
   long value;
 };
+
+/**
+ * @brief 커널 패닉 매크로
+ * PANIC 매크로를 무한 루프로 끝내는 이유?
+ * - 시스템 안정성
+   심각한 오류 발생 시 시스템이 불안정한 상태로 계속 실행되는 것을 방지
+   예측할 수 없는 동작이나 추가 손상을 막음
+ * - 디버깅 용이성
+   프로그램이 즉시 종료되는 대신 무한 루프에 걸리므로 디버거를 연결하여 상태
+   검사 오류 발생 시점의 메모리와 레지스터의 상태를 확인
+ * - 하드웨어 특성
+   임베디드 시스템에서는 단순히 exit()를 호출하는 것이 적절하지 않을 수 있음
+   워치독 타이머가 있는 경우 무한 루프는 시스템 리셋을 트리거 */
+#define PANIC(fmt, ...)                                                        \
+  do {                                                                         \
+    printf("PANIC: %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__);      \
+    while (1) {                                                                \
+    }                                                                          \
+  } while (0)


### PR DESCRIPTION

### Exception 발생 조건

- CPU가 잘못된 메모리 접근 (Page Fault)
- illegal instructions
- 시스템콜


### 예외가 발생할 경우 RISC-V 흐름 

- stvec에 예외 핸들러 주소 설정
- 코드 실행
- 예외 발생
- CPU가 stvec에 설정된 주소(kernel_entry)로 점프
- 예외 처리 시작
    - 현재 실행 컨텍스트 모두 저장
    - 예외 처리 함수 실행
    - 원래 컨텍스트 복원
    - 프로그램 재개

```mermaid
flowchart TB
    A[예외 발생] --> B[stvec 확인]
    B --> C[레지스터 백업]
    C --> D[예외 처리]
    D --> E[레지스터 복원]
    E --> F[프로그램 재개]
```

### kernel_main (예외 상황 의도적 발생)

RISC-V 내 프로세서의 상태를 제어하고 모니터링하는 레지스터 CSR에 예외 핸들러 주소인 kernel_entry 값을 쓰기 작업하고 예외가 발생하도록 unimp 실행하며 unimp는 어셈블러에서 `csrrw x0, cycle, x0` 로 변환되는데 cycle 레지스터는 읽기 전용 레지스터이므로 이곳에 쓰기 시도를 함으로써 illegal instruction 예외 상황을 발생시킴.

- **코드 원문**

```bash
169L,  WRITE_CSR(stvec, (uint32_t)kernel_entry);
170L,   __asm__ __volatile__("unimp"); 
```

- **실행 결과**
- `scause`: 어떤 이유로 예외가 발생했는지
- `stval`: 예외 부가정보 (잘못된 메모리 주소)
- `sepc`: 예외가 발생된 시점의 PC

```bash
# scause=2, Illegal instruction 예외
PANIC: kernel.c:67: unexpected trap scause=00000002, stval=00000000, sepc=80200130
```

- 예외가 발생한 명령어의 주소를 llvm-addr2line 커맨드로 디버그하여 소스 코드 내 위치로 변환 170번 라인 (`__asm__ __volatile__("unimp");`)

```bash
$ llvm-addr2line -e kernel.elf 80200130
/Users/jinhyeokhong/dev/go_work/src/operating-system/kernel.c:170
```

