### PR TITLE
[Chapter-10] 프로세스 생성 및 전환

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{  
-  "C_Cpp.errorSquiggles": "enabled"
-}

--- a/kernel.c
+++ b/kernel.c
@@ -14,10 +14,18 @@ struct process {
   int state;           // 프로세스 상태: PROC_UNUSED 또는 PROC_RUNNABLE
   vaddr_t sp;          // 스택 포인터
   uint8_t stack[8192]; // 커널 스택 (CPU 레지스터, 함수 리턴 주소, 로컬 변수)
-}
+};
 
 struct process procs[PROCS_MAX]; // 모든 프로세스 제어 구조체 배열
+struct process *current_proc;    // 현재 실행 중인 프로세스
+struct process *idle_proc;       // Idle 프로세스
 
+/**
+ * @brief 프로세스 생성
+ *
+ * @param pc 프로세스가 처음 실행할 주소
+ * @return struct process*  생성된 프로세스 구조체의 주소
+ */
 struct process *create_process(uint32_t pc) {
   // 미사용 상태의 프로세스 구조체 찾기
   struct process *proc = NULL;
@@ -195,6 +203,32 @@ __attribute__((naked)) void switch_context(uint32_t *prev_sp,
 }
 
 /**
+ * @brief 라운드 로빈 방식의 스케줄러 (순차적)
+ * 프로세스들이 자발적으로 CPU를 양보
+ * 우선순위나 실행 시간은 고려 x
+ */
+void yield(void) {
+  // 실행 가능한 프로세스 탐색
+  struct process *next = idle_proc;
+  for (int i = 0; i < PROCS_MAX; i++) {
+    struct process *proc = &procs[(current_proc->pid + i) % PROCS_MAX];
+    if (proc->state == PROC_RUNNABLE && proc->pid > 0) {
+      next = proc;
+      break;
+    }
+  }
+
+  // 현재 프로세스를 제외하고 실행 가능한 프로세스가 없다면 리턴
+  if (next == current_proc)
+    return;
+
+  // 컨텍스트 스위칭
+  struct process *prev = current_proc;
+  current_proc = next;
+  switch_context(&prev->sp, &next->sp);
+}
+
+/**
  * @brief 예외 처리 핸들러
  * 1. 현재 실행 컨텍스트를 모두 저장
  * 2. 예외 처리 함수 실행
@@ -276,20 +310,38 @@ __attribute__((naked)) __attribute__((aligned(4))) void kernel_entry(void) {
       "sret\n");             // 예외 처리 완료, 원래 실행 지점으로 복귀
 }
 
+void delay(void) {
+  for (int i = 0; i < 30000000; i++)
+    __asm__ __volatile__("nop"); // do nothing
+}
+
+struct process *proc_a;
+struct process *proc_b;
+
+void proc_a_entry(void) {
+  printf("starting process A\n");
+  while (1) {
+    putchar('A');
+    yield();
+  }
+}
+
+void proc_b_entry(void) {
+  printf("starting process B\n");
+  while (1) {
+    putchar('B');
+    yield();
+  }
+}
+
 // 커널 메인 함수
 void kernel_main(void) {
-  printf("\n\nHello %s\n", "World!");
-  printf("1 + 2 = %d, %x\n", 1 + 2, 0x1234abcd);
-
   /* BSS 영역 초기화 (BSS 영역만큼 버퍼를 0으로 채움)
    * 일부 부트로더가 .bss를 클리어해주기도 하지만 여러 환경에서 확실히 동작하게
    * 하려면 수동으로 초기화 하는 것이 안전 */
   memset(__bss, 0, (size_t)__bss_end - (size_t)__bss);
 
-  paddr_t paddr0 = alloc_pages(2);
-  paddr_t paddr1 = alloc_pages(1);
-  printf("alloc_pages test: paddr0=%x\n", paddr0);
-  printf("alloc_pages test: paddr1=%x\n", paddr1);
+  printf("\n\n");
 
   /*
    * 1. stvec 레지스터에 kernel_entry 함수의 주소(예외 핸들러)를 저장
@@ -299,7 +351,16 @@ void kernel_main(void) {
    * 5. 예외 처리 시작
    */
   WRITE_CSR(stvec, (uint32_t)kernel_entry);
-  __asm__ __volatile__("unimp"); // unimplemented instruction
+
+  idle_proc = create_process((uint32_t)NULL);
+  idle_proc->pid = 0; // idle
+  current_proc = idle_proc;
+
+  proc_a = create_process((uint32_t)proc_a_entry);
+  proc_b = create_process((uint32_t)proc_b_entry);
+
+  yield();
+  PANIC("switched to idle process");
 
   /*
     Hello World 메시지가 화면에 출력되는 과정 SBI 호출 시, 문자는 다음과 같이


### PR DESCRIPTION
### Callee-saved, Caller-saved 레지스터

callee-saved 레지스터란 `함수가 호출되었을 때 함수를 호출한 쪽에서 복원해야 하는 레지스터`를 말함
- 함수(callee)가 이 레지스터를 사용하려면 먼저 값을 저장했다가 함수 종료 전에 복원해야 함
- RISC-V에서는 ra(return address), sp(stack pointer), s0-s11(saved registers)가 해당
- 호출된 함수가 이 레지스터들의 값을 보존할 책임이 있음

반면, caller-saved 레지스터(`t0-t6`, `a0-a7`)는 함수 호출 시 값이 보존되지 않고 값을 보존하고 싶다면 함수를 호출하는 쪽(caller)에서 직접 지정해야 함

컨텍스트 스위칭에서 callee-saved 레지스터들을 스택에 저장하고 스택 포인터를 교체한 후 새 스택에서 callee-saved 레지스터를 복원하는 방법은 실행 컨텍스트를 임시 로컬 변수처럼 스택에 저장하여 단순하고 깔끔하게 구현, 이러한 레지스터 구분은 함수 호출 시 필요한 최소한의 레지스터만 저장/복원하여 성능을 최적화하기 위한 설계임.

### 컨텍스트 스위칭

```mermaid
graph TB
    subgraph "Process A Stack"
        A_TOP["Stack Top"]
        A_SP["SP (Stack Pointer)"]
        A_REGS["Saved Registers:<br/>ra<br/>s0-s11<br/>(13 * 4 = 52bytes)"]
        A_BTM["Stack Bottom"]
        
        A_TOP --> A_SP
        A_SP --> A_REGS
        A_REGS --> A_BTM
    end

    subgraph "Process B Stack"
        B_TOP["Stack Top"]
        B_SP["SP (Stack Pointer)"]
        B_REGS["Saved Registers:<br/>ra<br/>s0-s11<br/>(13 * 4 = 52bytes)"]
        B_BTM["Stack Bottom"]
        
        B_TOP --> B_SP
        B_SP --> B_REGS
        B_REGS --> B_BTM
    end

    STEP1["Save current context<br/>Store callee-saved registers"]
    STEP2["Switch Stack Pointer<br/>prev_sp = current SP<br/>SP = next_sp"]
    STEP3["Restore new context<br/>Load callee-saved registers"]

    STEP1 --> |"addi sp, sp, -52<br/>sw ra, s0-s11"| A_REGS
    A_SP --> |"sw sp, (a0)"| STEP2
    STEP2 --> |"lw sp, (a1)"| B_SP
    B_REGS --> |"lw ra, s0-s11<br/>addi sp, sp, 52"| STEP3
```

각 프로세스는 자신의 컨텍스트를 스택에 안전하게 보관하고 있음

1. 현재 프로세스(Process A)의 컨텍스트 저장
- 스택에 52바이트(13 * 4) 공간 확보
- callee-saved 레지스터 (ra, s0-s11) 저장

2. 스택 포인터 교체
- 현재 스택 포인터를 prev_sp에 저장
- 스택 포인터를 다음 프로세스(Process B)의 값으로 변경

3. 새 프로세스(Process B)의 컨텍스트 복원
- 저장된 레지스터들(ra, s0-s11) 복원
- 스택 포인터 조정
- 복원된 반환 주소(ra)로 이동

### 스케쥴러

프로세스가 많아지면 어느 프로세스가 다음에 실행될지 매번 결정하는 것이 복잡해지는데 이를 해결하기 위해 스케줄러(scheduler)를 작성해 실행 순서를 결정

### 스택 포인터를 매번 리셋해야 하는 이유

유저 모드에서 예외가 발생하게 되면 sp는 유저(애플리케이션)의 스택을 가리킬 수 있는데 이 스택 포인터를 커널이 그대로 써버리게 된다면 매핑되지 않은 주소에 접근하거나 악의적으로 조작된 주소에 접근하게 되어 커널이 오동작하거나 보안 취약점이 생길 수도 있음.

관련 보안 취약점 (CVE-2017-1000410)
- SP 레지스터를 조작하여 커널의 스택 전환 과정을 악용
- 특권 레벨 상승 취약점 발견
- 커널 메모리에 임의 코드 실행

KASLR (Kernel Address Space Layout Randomization)

- 커널의 기본 주소 값을 무작위로 만들어 커널 공격을 구현하기 어렵게 만드는 기능

--- 

https://www.lazenca.net/pages/viewpage.action?pageId=25624857
https://kernel.bz/boardPost/118681/4