### PR TITLE
[Chapter-12] 애플리케이션 구현

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 set -xue
 
 QEMU=qemu-system-riscv32
+OBJCOPY=/opt/homebrew/opt/llvm/bin/llvm-objcopy
 
 # clang 경로, 컴파일 옵션
 CC=/opt/homebrew/opt/llvm/bin/clang
@@ -17,6 +18,17 @@ CFLAGS=(
   -ffreestanding               # 호스트 표준 라이브러리를 사용하지 않음
   -nostdlib                    # 표준 라이브러리를 링크하지 않음
 )
+
+# 애플리케이션 빌드
+$CC "${CFLAGS[@]}" \
+  -Wl,-Tuser.ld \
+  -Wl,-Map=shell.map \
+  -o shell.elf \
+  shell.c user.c common.c
+
+# ELF 형식의 실행 파일을 실제 메모리 내용만 포함하는 바이너리로 변환
+$OBJCOPY --set-section-flags .bss=alloc,contents -O binary shell.elf shell.bin
+$OBJCOPY -Ibinary -Oelf32-littleriscv shell.bin shell.bin.o
 
 # 커널 빌드
 $CC "${CFLAGS[@]}" \

--- a/shell.c
+++ b/shell.c
@@ -1,0 +1,6 @@
+#include "user.h"
+
+void main(void) {
+  for (;;)
+    ;
+}

--- a/user.c
+++ b/user.c
@@ -1,0 +1,17 @@
+#include "user.h"
+
+extern char __stack_top[];
+
+__attribute__((noreturn)) void exit(void) {
+  for (;;)
+    ;
+}
+
+void putchar(char c) {}
+
+__attribute__((section(".text.start"))) __attribute__((naked)) void
+start(void) {
+  __asm__ __volatile__("mv sp, %[stack_top] \n"
+                       "call main \n"
+                       "call exit \n" ::[stack_top] "r"(__stack_top));
+}

--- a/user.h
+++ b/user.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "common.h"
+
+__attribute__((noreturn)) void exit(void);
+void putchar(char ch);

--- a/user.ld
+++ b/user.ld
@@ -1,0 +1,34 @@
+ENTRY(start)
+
+SECTIONS {
+  /* 현재 위치 카운터를 0x1000000 (16MB) 주소로 설정 */
+  . = 0x1000000;
+
+  /* 실행 코드를 포함 */
+  .text :{
+    KEEP(*(.text.start));
+    *(.text .text.*);
+  }
+
+  /* 읽기 전용 데이터(상수, 문자열 등)를 포함하는 섹션 */
+  .rodata : ALIGN(4) {
+    *(.rodata .rodata.*);
+  }
+
+  /* 초기화된 전역/정적 변수를 포함하는 섹션 */
+  .data : ALIGN(4) {
+    *(.data .data.*);
+  }
+
+  /* 초기화되지 않은 전역/정적 변수를 포함하는 섹션 */
+  .bss : ALIGN(4) {
+    *(.bss .bss.* .sbss .sbss.*);
+
+    . = ALIGN(16); /* 현재 위치를 16바이트 경계에 정렬 */
+    . += 64 * 1024; /* 현재 위치에 64KB(스택 영역)를 추가 */
+    __stack_top = .;
+
+    /* 최종 위치가 0x1800000(24MB)보다 작은지 확인 */
+    ASSERT(. < 0x1800000, "too large executable");
+  }
+}


### PR DESCRIPTION
## ELF(Executable and Linkable Format) vs 바이너리

### ELF

- ELF 파일은 헤더, 프로그램 헤더 테이블, 섹션 헤더 테이블, 그리고 실제 데이터 등 복잡한 구조를 가짐
- 심볼 테이블, 디버깅 정보, 재배치 정보 등 다양한 메타데이터를 포함
- 운영체제에서 실행 파일을 로드할 때 필요한 정보를 제공

### 순수 바이너리

- 단순히 메모리에 로드될 데이터만 포함
- 헤더나 메타데이터가 없으며 메모리에 그대로 복사해서 실행할 수 있는 형태
- 파일 크기가 ELF보다 작음

본문에서는 llvm-objcopy로 ELF 파일을 바이너리로 변환하는 이유를 바이너리 파일을 메모리에 로드해 애플리케이션을 실행할 예정이라고 설명, 일반적인 OS에서는 ELF 같은 형식을 사용해 `메모리 매핑 정보`와 `실제 메모리 내용`을 분리해서 다룸

### 보통의 이유 (ELF를 바이너리로 변환하는 이유)

- 베어메탈 환경이나 임베디드 시스템에서는 ELF 로더가 없는 경우가 많음
- ROM이나 플래시 메모리에 직접 코드를 구워 넣을 때는 순수 바이너리 형태가 필요
- 제한된 메모리를 가진 시스템에서 ELF의 오버헤드를 줄이고 필요한 코드와 데이터만 포함시킬 수 있음
- 많은 부트로더는 순수 바이너리 형식만 로드 가능
- 링커 스크립트에서 정의한 메모리 레이아웃대로 정확히 바이너리가 메모리에 로드됨

---


### 심볼테이블 확인 및 실행 파일 디스어셈블


```bash
$ llvm-nm shell.bin.o | grep _binary_shell_bin_size
00010250 A _binary_shell_bin_size
```

- `_binary_shell_bin_size`에는 파일 크기가 들어 있음
- 심볼테이블 중 `_binary_shell_bin_size`에 파일 크기를 '주소' 형태로 박아놓음


```bash
$ ls -al shell.bin
-rwxr-xr-x  1 jinhyeokhong  staff  66128  2 25 18:58 shell.bin
```
- 실제 파일 크기 확인 (66,128 B)


```python3
$ python3 -c 'print(0x10250)'
66128
```

- 0x10250 (16진수)은 66,128로 파일 크기와 동일


```bash
$ llvm-objdump -d shell.elf

shell.elf:	file format elf32-littleriscv

Disassembly of section .text:

01000000 <start>:
 1000000: 01010537     	lui	a0, 0x1010
 1000004: 25050513     	addi	a0, a0, 0x250
 1000008: 812a         	mv	sp, a0
 100000a: 2011         	jal	0x100000e <main>
 100000c: 2011         	jal	0x1000010 <exit>

0100000e <main>:
 100000e: a001         	j	0x100000e <main>

01000010 <exit>:
 1000010: a001         	j	0x1000010 <exit>
```

메모리 레이아웃대로 `.text.start` 섹션이 실행 파일의 맨 앞에 배치, start 함수 실제 주소가 `0x1000000`
