### PR TITLE
[Chapter-13] 유저 모드 구현하기

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -19,7 +19,27 @@ extern char __free_ram[], __free_ram_end[];
 // shell.bin.o에 포함된 원시 바이너리 사용
 extern char _binary_shell_bin_start[], _binary_shell_bin_size[];
 
-void user_entry(void) { PANIC("not yet implemented"); }
+/**
+ * @brief 사용자 모드 진입 함수
+ *
+ */
+__attribute__((naked)) void user_entry(void) {
+  __asm__ __volatile__(
+      /* sepc(Supervisor Exception Program Counter) 레지스터에 USER_BASE 값을 씀
+       * 이 레지스터는 sret 명령어 실행 시 프로그램이 돌아갈 주소를 지정
+       * 즉, 사용자 프로그램(USER_BASE 주소)으로 점프 */
+      "csrw sepc, %[sepc] \n"
+
+      /* sstatus(Supervisor Status) 레지스터에 SSTATUS_SPIE 값을 씀
+       * SSTATUS_SPIE는 인터럽트 활성화 상태와 관련된 비트 */
+      "csrw sstatus, %[sstatus] \n"
+
+      /* Supervisor Return, 예외 처리를 완료하고 sepc에 저장된 주소로 복귀
+       * 특권 모드에서 사용자 모드로 전환 */
+      "sret \n"
+      :
+      : [sepc] "r"(USER_BASE), [sstatus] "r"(SSTATUS_SPIE));
+}
 
 /** Bump Allocator / Linear Allocator
  * @brief  메모리 할당 함수, (메모리 해제 기능 없음)

--- a/kernel.c
+++ b/kernel.c
@@ -16,6 +16,11 @@ struct process *idle_proc;       // Idle 프로세스
 extern char __kernel_base[];
 extern char __free_ram[], __free_ram_end[];
 
+// shell.bin.o에 포함된 원시 바이너리 사용
+extern char _binary_shell_bin_start[], _binary_shell_bin_size[];
+
+void user_entry(void) { PANIC("not yet implemented"); }
+
 /** Bump Allocator / Linear Allocator
  * @brief  메모리 할당 함수, (메모리 해제 기능 없음)
  *
@@ -78,12 +83,14 @@ void map_page(uint32_t *table1, uint32_t vaddr, paddr_t paddr, uint32_t flags) {
 }
 
 /**
- * @brief 프로세스 생성
+ * @brief 프로세스 생성, 지정된 크기만큼 실행된 이미지를 페이지 단위로 복사하여
+ * 프로세스의 페이지 테이블에 매핑
  *
- * @param pc 프로세스가 처음 실행할 주소
- * @return struct process*  생성된 프로세스 구조체의 주소
+ * @param image 실행 이미지의 포인터
+ * @param image_size 이미지 크기
+ * @return struct process* 생성된 프로세스 구조체의 주소
  */
-struct process *create_process(uint32_t pc) {
+struct process *create_process(const void *image, size_t image_size) {
   // 미사용 상태의 프로세스 구조체 찾기
   struct process *proc = NULL;
   int i;
@@ -103,25 +110,43 @@ struct process *create_process(uint32_t pc) {
 
   // 커널 스택에 callee-saved 레지스터 공간을 미리 준비
   // 첫 컨텍스트 스위치 시, switch_context에서 이 값들을 복원
-  *--sp = 0;            // s11
-  *--sp = 0;            // s10
-  *--sp = 0;            // s9
-  *--sp = 0;            // s8
-  *--sp = 0;            // s7
-  *--sp = 0;            // s6
-  *--sp = 0;            // s5
-  *--sp = 0;            // s4
-  *--sp = 0;            // s3
-  *--sp = 0;            // s2
-  *--sp = 0;            // s1
-  *--sp = 0;            // s0
-  *--sp = (uint32_t)pc; // ra (처음 실행 시 점프할 주소)
+  *--sp = 0;                    // s11
+  *--sp = 0;                    // s10
+  *--sp = 0;                    // s9
+  *--sp = 0;                    // s8
+  *--sp = 0;                    // s7
+  *--sp = 0;                    // s6
+  *--sp = 0;                    // s5
+  *--sp = 0;                    // s4
+  *--sp = 0;                    // s3
+  *--sp = 0;                    // s2
+  *--sp = 0;                    // s1
+  *--sp = 0;                    // s0
+  *--sp = (uint32_t)user_entry; // ra (처음 실행 시 점프할 주소)
 
   uint32_t *page_table = (uint32_t *)alloc_pages(1);
+
   // 커널 메모리 영역을 일대일 방식으로 매핑
   for (paddr_t paddr = (paddr_t)__kernel_base; paddr < (paddr_t)__free_ram_end;
        paddr += PAGE_SIZE)
     map_page(page_table, paddr, paddr, PAGE_R | PAGE_W | PAGE_X);
+
+  // 루프를 사용하여 이미지를 페이지 단위로 처리
+  for (uint32_t off = 0; off < image_size; off += PAGE_SIZE) {
+    // 새 물리 메모리 페이지 할당
+    paddr_t page = alloc_pages(1);
+
+    // 현재 오프셋에서 복사할 크기를 계산
+    size_t remaining = image_size - off;
+    size_t copy_size = PAGE_SIZE <= remaining ? PAGE_SIZE : remaining;
+
+    // 이미지 데이터를 새로 할당된 페이지에 복사
+    memcpy((void *)page, image + off, copy_size);
+
+    // 가상 메모리 주소를 물리 메모리에 매핑
+    map_page(page_table, USER_BASE + off, page,
+             PAGE_U | PAGE_R | PAGE_W | PAGE_X);
+  }
 
   // 구조체 필드 초기화
   proc->pid = i + 1;
@@ -415,12 +440,11 @@ void kernel_main(void) {
    */
   WRITE_CSR(stvec, (uint32_t)kernel_entry);
 
-  idle_proc = create_process((uint32_t)NULL);
+  idle_proc = create_process(NULL, 0);
   idle_proc->pid = 0; // idle
   current_proc = idle_proc;
 
-  proc_a = create_process((uint32_t)proc_a_entry);
-  proc_b = create_process((uint32_t)proc_b_entry);
+  create_process(_binary_shell_bin_start, (size_t)_binary_shell_bin_size);
 
   yield();
   PANIC("switched to idle process");

--- a/kernel.h
+++ b/kernel.h
@@ -9,6 +9,9 @@
 #define PAGE_X (1 << 3)      // 실행 가능
 #define PAGE_U (1 << 4)      // 사용자 모드 접근 가능
 
+// 애플리케이션 이미지의 기본 가상 주소
+#define USER_BASE 0x1000000
+
 struct process {
   int pid;              // 프로세스 ID
   int state;            // 프로세스 상태: PROC_UNUSED 또는 PROC_RUNNABLE

--- a/kernel.h
+++ b/kernel.h
@@ -12,6 +12,8 @@
 // 애플리케이션 이미지의 기본 가상 주소
 #define USER_BASE 0x1000000
 
+#define SSTATUS_SPIE (1 << 5)
+
 struct process {
   int pid;              // 프로세스 ID
   int state;            // 프로세스 상태: PROC_UNUSED 또는 PROC_RUNNABLE

--- a/run.sh
+++ b/run.sh
@@ -35,7 +35,7 @@ $CC "${CFLAGS[@]}" \
   -Wl,-Tkernel.ld \
   -Wl,-Map=kernel.map \
   -o kernel.elf \
-  kernel.c common.c
+  kernel.c common.c shell.bin.o
 
 # virt 머신 시작
 # QEMU가 제공하는 기본 펌웨어(OpenSBI)를 사용

--- a/shell.c
+++ b/shell.c
@@ -1,6 +1,7 @@
 #include "user.h"
 
 void main(void) {
+  // *((volatile int *)0x80200000) = 0x1234;
   for (;;)
     ;
 }


### PR DESCRIPTION
루프 내에서 이미지를 페이지 단위로 처리할 때 오프셋마다 이미지 데이터를 새로 할당된 페이지에 "복사"하는 이유는 동일한 애플리케이션의 프로세스들이 동일한 물리 페이지를 공유하여 메모리 격리를 파괴하는 상황을 막기 위해서임. 더 잘 이해하기 위해서는 운영체제에서 프로세스를 생성하는 접근 방식을 살펴봐야함.

### 운영체제의 프로세스 생성 방식

운영체제에서 새로운 프로세스를 생성할 때는 두 가지 접근 방식이 존재
- `복사 방식`: 원본 이미지의 데이터를 새로운 물리 페이지에 복사한 후 매핑
- `직접 매핑 방식`: 원본 이미지가 있는 물리 페이지를 여러 프로세스의 가상 주소 공간에 직접 매핑

### 직접 매핑의 문제점

- 쓰기 공유로 인한 데이터 오염: 동일한 애플리케이션을 실행하는 여러 프로세스가 같은 물리 메모리를 공유함
- 한 프로세스가 해당 메모리에 쓰기 작업을 수행하면 모든 프로세스에서 그 변경사항이 보이게 됨
- 이로 인해 프로세스 A의 데이터가 프로세스 B에 의해 의도치 않게 수정될 수 있음
- 권한 상승 공격이나 데이터 탈취로 이어질 수 있음

**이미지를 복사하는 방식은 더 많은 메모리를 사용하지만 프로세스 간 메모리 격리라는 중요한 보안 원칙을 유지, 직접 매핑은 메모리 사용량을 줄일 수는 있어도 보안과 안정성을 심각하게 훼손할 수 있으므로 일반적으로 사용하지 않으며 현대 운영체제는 효율성을 위해 Copy-on-Write(CoW) 같은 최적화 기법을 사용하여 두 가지 목표를 모두 달성.**

---

### 가상 메모리 매핑 검증 과정

```bash
(qemu) info mem
vaddr    paddr            size     attr
-------- ---------------- -------- -------
01000000 0000000080265000 00001000 rwxu---
01001000 0000000080267000 00010000 rwxu---
80200000 0000000080200000 00001000 rwx--a-
```

- info mem 명령으로 가상 주소와 물리 주소 간의 매핑 관계 확인
- 물리 주소 `0x80265000`가 가상 주소 `0x1000000` (USER_BASE, kernel.h)에 매핑


```bash
(qemu) xp /32b 0x80265000
0000000080265000: 0x37 0x05 0x01 0x01 0x13 0x05 0x05 0x25
0000000080265008: 0x2a 0x81 0x11 0x20 0x11 0x20 0x01 0xa0
0000000080265010: 0x01 0xa0 0x82 0x80 0x09 0xce 0x2a 0x96
0000000080265018: 0xaa 0x86 0x03 0xc7 0x05 0x00 0x85 0x05
```

- 물리 메모리의 내용을 표시하기 위해 xp 명령어를 사용
- **물리 메모리 주소 `0x80265000`부터 32개 바이트를 출력**

```bash
$ hexdump -C shell.bin | head
00000000  37 05 01 01 13 05 05 25  2a 81 11 20 11 20 01 a0  |7......%*.. . ..|
00000010  01 a0 82 80 09 ce 2a 96  aa 86 03 c7 05 00 85 05  |......*.........|
00000020  93 87 16 00 23 80 e6 00  be 86 e3 98 c7 fe 82 80  |....#...........|
00000030  11 ca 2a 96 aa 86 13 87  16 00 23 80 b6 00 ba 86  |..*.......#.....|
00000040  e3 1b c7 fe 82 80 03 c6  05 00 aa 86 01 ce 85 05  |................|
00000050  2a 87 23 00 c7 00 03 c6  05 00 93 06 17 00 85 05  |*.#.............|
00000060  36 87 65 fa 23 80 06 00  82 80 03 46 05 00 19 ca  |6.e.#......F....|
00000070  05 05 83 c6 05 00 63 17  d6 00 03 46 05 00 85 05  |......c....F....|
00000080  05 05 65 fa 03 c5 05 00  33 05 a6 40 82 80 1d 71  |..e.....3..@...q|
00000090  06 de 22 dc 26 da 4a d8  4e d6 52 d4 56 d2 5a d0  |..".&.J.N.R.V.Z.|
```

- shell.bin 파일의 내용을 16진수 형식으로 출력, 위 내용과 실제로 일치

### 디스어셈블

```bash
(qemu) xp /8i 0x80265000
0x80265000:  01010537          lui                     a0,4112
0x80265004:  25050513          addi                    a0,a0,592
0x80265008:  812a              mv                      sp,a0
0x8026500a:  2011              jal                     ra,4                    # 0x8026500e
0x8026500c:  2011              jal                     ra,4                    # 0x80265010
0x8026500e:  a001              j                       0                       # 0x8026500e
0x80265010:  a001              j                       0                       # 0x80265010
0x80265012:  8082              ret    
```

- QEMU 디버거에서 물리 메모리의 내용을 어셈블리 명령어로 해석해서 보여줌
- 기계어 코드를 어셈블리 명령어로 변환하여 그 차이를 확인

```bash
$ llvm-objdump -d shell.elf | head -n20

shell.elf:      file format elf32-littleriscv

Disassembly of section .text:

01000000 <start>:
 1000000: 01010537      lui     a0, 0x1010
 1000004: 25050513      addi    a0, a0, 0x250
 1000008: 812a          mv      sp, a0
 100000a: 2011          jal     0x100000e <main>
 100000c: 2011          jal     0x1000010 <exit>

0100000e <main>:
 100000e: a001          j       0x100000e <main>

01000010 <exit>:
 1000010: a001          j       0x1000010 <exit>

01000012 <putchar>:
 1000012: 8082          ret
```

- objdump로 shell.elf 파일을 디스어셈블하고 위 결과와 비교, 일치


