### PR TITLE
[Chapter-16] 파일시스템 (TAR-ustar)

### DIFF
--- a/common.h
+++ b/common.h
@@ -11,6 +11,8 @@ typedef uint32_t size_t;
 #define SYS_PUTCHAR 1
 #define SYS_GETCHAR 2
 #define SYS_EXIT 3
+#define SYS_READFILE 4
+#define SYS_WRITEFILE 5
 
 // 물리 메모리 주소를 나타내는 타입 (pysical memory address)
 typedef uint32_t paddr_t;

--- a/kernel.c
+++ b/kernel.c
@@ -9,6 +9,10 @@ typedef uint32_t size_t;
 #define PROC_UNUSED 0   // 사용되지 않는 프로세스 구조체
 #define PROC_RUNNABLE 1 // 실행 가능한 프로세스
 
+extern struct file files[FILES_MAX];
+extern uint8_t disk[DISK_MAX_SIZE];
+void read_write_disk(void *buf, unsigned sector, int is_write);
+
 struct process procs[PROCS_MAX]; // 모든 프로세스 제어 구조체 배열
 struct process *current_proc;    // 현재 실행 중인 프로세스
 struct process *idle_proc;       // Idle 프로세스
@@ -36,7 +40,7 @@ __attribute__((naked)) void user_entry(void) {
        * 특권 모드에서 사용자 모드로 전환 */
       "sret \n"
       :
-      : [sepc] "r"(USER_BASE), [sstatus] "r"(SSTATUS_SPIE));
+      : [sepc] "r"(USER_BASE), [sstatus] "r"(SSTATUS_SPIE | SSTATUS_SUM));
 }
 
 /** Bump Allocator / Linear Allocator
@@ -440,6 +444,73 @@ long getchar(void) {
   return ret.error;
 }
 
+// 파일명을 기준으로 파일을 검색
+struct file *fs_lookup(const char *filename) {
+  for (int i = 0; i < FILES_MAX; i++) {
+    struct file *file = &files[i];
+    if (!strcmp(file->name, filename))
+      return file;
+  }
+
+  return NULL;
+}
+
+// TAR 형식으로 파일 시스템을 구성하고 가상 블록 장치에 저장
+void fs_flush(void) {
+
+  // 모든 파일 내용을 'disk' 버퍼에 복사
+  memset(disk, 0, sizeof(disk));
+
+  // 현재 디스크 오프셋 위치를 추적
+  unsigned off = 0;
+
+  // 모든 파일을 순회하며 TAR 형식으로 디스크에 저장
+  for (int file_i = 0; file_i < FILES_MAX; file_i++) {
+    struct file *file = &files[file_i];
+    if (!file->in_use) // 사용중이지 않으면 건너뜀
+      continue;
+
+    // TAR 헤더 구성
+    struct tar_header *header = (struct tar_header *)&disk[off];
+    memset(header, 0, sizeof(*header));
+    strcpy(header->name, file->name);
+    strcpy(header->mode, "000644");
+    strcpy(header->magic, "ustar");
+    strcpy(header->version, "00");
+    header->type = '0';
+
+    // 파일 크기를 8진수 문자열로 변환하여 헤더에 설정
+    int filesz = file->size;
+    for (int i = sizeof(header->size); i > 0; i--) {
+      header->size[i - 1] = (filesz % 8) + '0';
+      filesz /= 8;
+    }
+
+    // 헤더 체크섬 계산
+    int checksum = ' ' * sizeof(header->checksum);
+    for (unsigned i = 0; i < sizeof(struct tar_header); i++)
+      checksum += (unsigned char)disk[off + i];
+
+    // 계산된 체크섬을 8진수 문자열로 변환하여 헤더에 설정
+    for (int i = 5; i >= 0; i--) {
+      header->checksum[i] = (checksum % 8) + '0';
+      checksum /= 8;
+    }
+
+    // 파일 데이터를 헤더 뒤에 복사
+    memcpy(header->data, file->data, file->size);
+
+    // 다음 파일을 위해 오프셋 업데이트 (섹터 크기에 맞게 정렬)
+    off += align_up(sizeof(struct tar_header) + file->size, SECTOR_SIZE);
+  }
+
+  // disk 버퍼의 내용을 virtio-blk 디바이스에 기록
+  for (unsigned sector = 0; sector < sizeof(disk) / SECTOR_SIZE; sector++)
+    read_write_disk(&disk[sector * SECTOR_SIZE], sector, true);
+
+  printf("wrote %d bytes to disk\n", sizeof(disk));
+}
+
 // 시스템 콜의 종류를 판별하여 처리
 void handle_syscall(struct trap_frame *f) {
   // 시스템 콜 번호가 담긴 a3 레지스터 확인
@@ -466,6 +537,32 @@ void handle_syscall(struct trap_frame *f) {
   case SYS_PUTCHAR:
     putchar(f->a0);
     break;
+  case SYS_READFILE:
+  case SYS_WRITEFILE: {
+    const char *filename = (const char *)f->a0;
+    char *buf = (char *)f->a1;
+    int len = f->a2;
+    struct file *file = fs_lookup(filename);
+    if (!file) {
+      printf("file not found: %s\n", filename);
+      f->a0 = -1;
+      break;
+    }
+
+    if (len > (int)sizeof(file->data))
+      len = file->size;
+
+    if (f->a3 == SYS_WRITEFILE) {
+      memcpy(file->data, buf, len);
+      file->size = len;
+      fs_flush();
+    } else {
+      memcpy(buf, file->data, len);
+    }
+
+    f->a0 = len;
+    break;
+  }
   default:
     PANIC("unexpected syscall a3=%x\n", f->a3);
   }
@@ -707,62 +804,6 @@ void fs_init(void) {
     // 다음 파일 헤더로 이동
     off += align_up(sizeof(struct tar_header) + filesz, SECTOR_SIZE);
   }
-}
-
-// TAR 형식으로 파일 시스템을 구성하고 가상 블록 장치에 저장
-void fs_flush(void) {
-
-  // 모든 파일 내용을 'disk' 버퍼에 복사
-  memset(disk, 0, sizeof(disk));
-
-  // 현재 디스크 오프셋 위치를 추적
-  unsigned off = 0;
-
-  // 모든 파일을 순회하며 TAR 형식으로 디스크에 저장
-  for (int file_i = 0; file_i < FILES_MAX; file_i++) {
-    struct file *file = &files[file_i];
-    if (!file->in_use) // 사용중이지 않으면 건너뜀
-      continue;
-
-    // TAR 헤더 구성
-    struct tar_header *header = (struct tar_header *)&disk[off];
-    memset(header, 0, sizeof(*header));
-    strcpy(header->name, file->name);
-    strcpy(header->mode, "000644");
-    strcpy(header->magic, "ustar");
-    strcpy(header->version, "00");
-    header->type = '0';
-
-    // 파일 크기를 8진수 문자열로 변환하여 헤더에 설정
-    int filesz = file->size;
-    for (int i = sizeof(header->size); i > 0; i--) {
-      header->size[i - 1] = (filesz % 8) + '0';
-      filesz /= 8;
-    }
-
-    // 헤더 체크섬 계산
-    int checksum = ' ' * sizeof(header->checksum);
-    for (unsigned i = 0; i < sizeof(struct tar_header); i++)
-      checksum += (unsigned char)disk[off + i];
-
-    // 계산된 체크섬을 8진수 문자열로 변환하여 헤더에 설정
-    for (int i = 5; i >= 0; i--) {
-      header->checksum[i] = (checksum % 8) + '0';
-      checksum /= 8;
-    }
-
-    // 파일 데이터를 헤더 뒤에 복사
-    memcpy(header->data, file->data, file->size);
-
-    // 다음 파일을 위해 오프셋 업데이트 (섹터 크기에 맞게 정렬)
-    off += align_up(sizeof(struct tar_header) + file->size, SECTOR_SIZE);
-  }
-
-  // disk 버퍼의 내용을 virtio-blk 디바이스에 기록
-  for (unsigned sector = 0; sector < sizeof(disk) / SECTOR_SIZE; sector++)
-    read_write_disk(&disk[sector * SECTOR_SIZE], sector, true);
-
-  printf("wrote %d bytes to disk\n", sizeof(disk));
 }
 
 // 커널 메인 함수

--- a/kernel.h
+++ b/kernel.h
@@ -2,7 +2,10 @@
 #include "common.h"
 
 #define FILES_MAX 2
-#define DISK_MAX_SIZE align_up(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)
+// #define DISK_MAX_SIZE align_up(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)
+
+#define ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
+#define DISK_MAX_SIZE ALIGN_UP(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)
 
 // #define ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 // #define DISK_MAX_SIZE ALIGN_UP(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)

--- a/kernel.h
+++ b/kernel.h
@@ -6,6 +6,7 @@
 
 #define ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 #define DISK_MAX_SIZE ALIGN_UP(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)
+#define SSTATUS_SUM (1 << 18)
 
 // #define ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 // #define DISK_MAX_SIZE ALIGN_UP(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)

--- a/kernel.h
+++ b/kernel.h
@@ -1,6 +1,38 @@
 #pragma once
 #include "common.h"
 
+#define FILES_MAX 2
+#define DISK_MAX_SIZE align_up(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)
+
+// 총 512바이트 크기의 파일에 대한 메타데이터를 포함
+struct tar_header {
+  char name[100];     // 파일의 이름
+  char mode[8];       // 파일의 권한 모드
+  char uid[8];        // 파일 소유자 8진수
+  char gid[8];        // 파일 소유자 그룹 8진수
+  char size[12];      // 파일 크기
+  char mtime[12];     // 마지막 수정 시간
+  char checksum[8];   // 헤더 블록의 체크섬 값
+  char type;          // 파일의 타입
+  char linkname[100]; // 링크가 가리키는 원본 파일명
+  char magic[6];      // ustar 형식임을 식별
+  char version[2];    // ustar 버전
+  char uname[32];     // 소유자 이름
+  char gname[32];     // 그룹의 이름
+  char devmajor[8];   // 장치 파일의 경우, 주 번호
+  char devminor[8];   // 장치 파일의 경우, 부 번호
+  char prefix[155];   // 긴 파일명을 지원하기 위한 추가 접두사
+  char padding[12];   // 헤더 크기를 512바이트로 맞추기 위한 패딩
+  char data[];        // 가변 크기 배열, 실제 파일 데이터는 헤더 이후 위치
+} __attribute__((packed));
+
+struct file {
+  bool in_use;
+  char name[100];
+  char data[1024];
+  size_t size;
+}
+
 // virtio 관련 매크로
 #define SECTOR_SIZE 512    // 디스크 섹터 크기 512바이트
 #define VIRTQ_ENTRY_NUM 16 // 가상 큐 엔트리 수 16개

--- a/kernel.h
+++ b/kernel.h
@@ -4,6 +4,22 @@
 #define FILES_MAX 2
 #define DISK_MAX_SIZE align_up(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)
 
+// #define ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
+// #define DISK_MAX_SIZE ALIGN_UP(sizeof(struct file) * FILES_MAX, SECTOR_SIZE)
+
+/* tar 파일은 아래와 같은 구조
+  +----------------+
+  |   tar header   |
+  +----------------+
+  |   file data    |
+  +----------------+
+  |   tar header   |
+  +----------------+
+  |   file data    |
+  +----------------+
+  |      ...       |
+ */
+
 // 총 512바이트 크기의 파일에 대한 메타데이터를 포함
 struct tar_header {
   char name[100];     // 파일의 이름
@@ -31,7 +47,7 @@ struct file {
   char name[100];
   char data[1024];
   size_t size;
-}
+};
 
 // virtio 관련 매크로
 #define SECTOR_SIZE 512    // 디스크 섹터 크기 512바이트

--- a/run.sh
+++ b/run.sh
@@ -37,10 +37,13 @@ $CC "${CFLAGS[@]}" \
   -o kernel.elf \
   kernel.c common.c shell.bin.o
 
+(cd disk && tar cf ../disk.tar --format=ustar -- *.txt)
+
 # virt 머신 시작
 # QEMU가 제공하는 기본 펌웨어(OpenSBI)를 사용
 # GUI 없이 콘솔만
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
   -kernel kernel.elf \
   -d unimp,guest_errors,int,cpu_reset -D qemu.log \
-  -device virtio-blk-device,drive=drive0,bus=virtio-mmio-bus.0 -drive id=drive0,file=lorem.txt,format=raw,if=none
+  -device virtio-blk-device,drive=drive0,bus=virtio-mmio-bus.0 -drive id=drive0,file=lorem.txt,format=raw,if=none \
+  -drive id=drive0,file=disk.tar,format=raw,if=none

--- a/run.sh
+++ b/run.sh
@@ -45,5 +45,5 @@ $CC "${CFLAGS[@]}" \
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
   -kernel kernel.elf \
   -d unimp,guest_errors,int,cpu_reset -D qemu.log \
-  -device virtio-blk-device,drive=drive0,bus=virtio-mmio-bus.0 -drive id=drive0,file=lorem.txt,format=raw,if=none \
-  -drive id=drive0,file=disk.tar,format=raw,if=none
+  -drive id=drive0,file=disk.tar,format=raw,if=none \
+  -device virtio-blk-device,drive=drive0,bus=virtio-mmio-bus.0

--- a/shell.c
+++ b/shell.c
@@ -29,6 +29,13 @@ void main(void) {
       printf("Hello world from shell!\n");
     else if (strcmp(cmdline, "exit") == 0)
       exit();
+    else if (strcmp(cmdline, "readfile") == 0) {
+      char buf[128];
+      int len = readfile("hello.txt", buf, sizeof(buf));
+      buf[len] = '\0';
+      printf("%s\n", buf);
+    } else if (strcmp(cmdline, "writefile") == 0)
+      writefile("hello.txt", "Hello from shell!\n", 19);
     else
       printf("unknown command: %s\n", cmdline);
   }

--- a/user.c
+++ b/user.c
@@ -37,6 +37,15 @@ void putchar(char ch) { syscall(SYS_PUTCHAR, ch, 0, 0); }
 
 int getchar(void) { return syscall(SYS_GETCHAR, 0, 0, 0); }
 
+// 파일 읽기 및 쓰기
+int readfile(const char *filename, char *buf, int len) {
+  return syscall(SYS_READFILE, (int)filename, (int)buf, len);
+}
+
+int writefile(const char *filename, const char *buf, int len) {
+  return syscall(SYS_WRITEFILE, (int)filename, (int)buf, len);
+}
+
 __attribute__((noreturn)) void exit(void) {
   syscall(SYS_EXIT, 0, 0, 0);
   for (;;)

--- a/user.h
+++ b/user.h
@@ -4,3 +4,5 @@
 __attribute__((noreturn)) void exit(void);
 void putchar(char ch);
 int getchar(void);
+int readfile(const char *filename, char *buf, int len);
+int writefile(const char *filename, const char *buf, int len);


### PR DESCRIPTION
### ustar 포맷 (Unix Standard TAR)

ustar는 유닉스 계열 시스템에서 여러 파일을 하나의 아카이브로 묶는 데 사용되는 파일 포맷, 이 포맷은 POSIX.1-1988 표준으로 지정, 기존 tar 포맷의 확장 버전

### 주요 특징

- 표준화: ustar는 여러 유닉스 계열 시스템 간 호환성을 높이기 위해 표준화
- 헤더 구조: 각 파일은 512 바이트 헤더로 시작, 헤더에는 다음과 같은 정보가 포함
  - `파일명 (최대 100자)`
  - `파일 모드 (권한)`
  - `소유자/그룹 ID`
  - `파일 크기`
  - `수정 시간`
  - `체크섬`
  - `파일 타입 플래그`
  - `링크된 파일명`
 - `매직 식별자`: ustar 포맷의 헤더는 "ustar" 매직 문자열(257-262바이트 위치)을 포함
 - `긴 파일명 지원`: 헤더에 파일명 접두사 필드를 추가하여 최대 256자까지 가능
 - `다양한 파일 타입`

### 실제 데이터 저장 방식

1. 모든 파일은 헤더(512바이트)로 시작
2. 헤더 다음에는 파일 내용이 512바이트 블록으로 나뉘어 저장
3. 파일 크기가 512의 배수가 아닌 경우, 마지막 블록은 0으로 패딩
4. 아카이브의 끝은 모두 0으로 채워진 512바이트 블록 두 개로 표시

---

### 리눅스의 `read(2)`와 `write(2)` 시스템 호출이 파일 이름 대신 파일 디스크립터를 인자로 받는 이유

1. **성능 효율성**: 파일 이름을 사용할 경우, 매 호출마다 파일 경로를 파싱하고 파일 시스템을 검색해야 하지만 파일 디스크립터는 간단한 정수값이므로 이미 열린 파일을 빠르게 참조 가능
2. **리소스 관리**: 파일 디스크립터는 프로세스 내에서 열린 파일/소켓/파이프 등의 리소스를 추적하는 방법
3. **파일 상태 유지**: 파일 디스크립터는 현재 읽기/쓰기 위치(offset), 모드, 권한 등의 상태 정보를 유지하므로 연속적인 read/write 호출이 이전 위치에서 이어서 작업 가능
4. **"모든 것은 파일"이란 철학**: 유닉스/리눅스에서는 소켓, 파이프, 디바이스 등 다양한 리소스도 파일로 추상화, 파일 디스크립터를 사용함으로써 이 모든 리소스에 동일한 인터페이스를 제공
5. **보안과 접근 제어**: 파일이 처음 열릴 때만 권한 검사를 수행하므로 효율적이며 디스크립터가 있따는 것은 이미 해당 리소스에 대한 접근 권한이 있음을 의미

